### PR TITLE
Adding test cases for DS-1186

### DIFF
--- a/modules/integration/tests-integration/tests/src/test/java/org/wso2/dss/integration/test/jira/issues/DS1186JsonRenderTestCase.java
+++ b/modules/integration/tests-integration/tests/src/test/java/org/wso2/dss/integration/test/jira/issues/DS1186JsonRenderTestCase.java
@@ -26,7 +26,6 @@ import org.wso2.carbon.automation.test.utils.http.client.HttpResponse;
 import org.wso2.carbon.registry.resource.stub.ResourceAdminServiceExceptionException;
 import org.wso2.dss.integration.common.clients.ResourceAdminServiceClient;
 import org.wso2.dss.integration.test.DSSIntegrationTest;
-
 import javax.activation.DataHandler;
 import javax.xml.xpath.XPathExpressionException;
 import java.io.BufferedReader;
@@ -57,7 +56,6 @@ public class DS1186JsonRenderTestCase extends DSSIntegrationTest {
                 new DataHandler(new URL("file:///" + getResourceLocation() + File.separator + "samples" + File.separator + "dbs" + File.separator + "rdbms"
                         + File.separator + "JsonRenderService.dbs")));
         serviceEndPoint = getServiceUrlHttps(serviceName) + "/";
-
     }
 
     @AfterClass(alwaysRun = true)
@@ -74,7 +72,6 @@ public class DS1186JsonRenderTestCase extends DSSIntegrationTest {
         String expectedResult = "{\"Entries\":{\"Entry\":[{\"status\":\"1 & 2\"}]}}";
         Assert.assertNotNull(receivedResult, "Response is null");
         Assert.assertTrue(expectedResult.equals(receivedResult.toString()), "Expected result not found");
-
     }
 
     /**
@@ -121,6 +118,13 @@ public class DS1186JsonRenderTestCase extends DSSIntegrationTest {
         return null;
     }
 
+    /**
+     * This method add the Security policy which will be used with the service.
+     * @throws RemoteException
+     * @throws MalformedURLException
+     * @throws ResourceAdminServiceExceptionException
+     * @throws XPathExpressionException
+     */
     private void addResource()
             throws RemoteException, MalformedURLException, ResourceAdminServiceExceptionException,
             XPathExpressionException {
@@ -134,7 +138,13 @@ public class DS1186JsonRenderTestCase extends DSSIntegrationTest {
                         + "SecPolicy-withRoles.xml")));
     }
 
-
+    /**
+     * Delete the security policy from the registry.
+     * @throws RemoteException
+     * @throws MalformedURLException
+     * @throws ResourceAdminServiceExceptionException
+     * @throws XPathExpressionException
+     */
     private void deleteResource()
             throws RemoteException, MalformedURLException, ResourceAdminServiceExceptionException,
             XPathExpressionException {
@@ -142,8 +152,4 @@ public class DS1186JsonRenderTestCase extends DSSIntegrationTest {
                 , sessionCookie);
         resourceAdmin.deleteResource("/_system/config/automation/resources/policies/");
     }
-
-
-
-
 }

--- a/modules/integration/tests-integration/tests/src/test/java/org/wso2/dss/integration/test/jira/issues/DS1186JsonRenderTestCase.java
+++ b/modules/integration/tests-integration/tests/src/test/java/org/wso2/dss/integration/test/jira/issues/DS1186JsonRenderTestCase.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright (c) 2015, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wso2.dss.integration.test.jira.issues;
+
+import org.apache.commons.codec.binary.Base64;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+import org.wso2.carbon.automation.test.utils.http.client.HttpResponse;
+import org.wso2.carbon.registry.resource.stub.ResourceAdminServiceExceptionException;
+import org.wso2.dss.integration.common.clients.ResourceAdminServiceClient;
+import org.wso2.dss.integration.test.DSSIntegrationTest;
+
+import javax.activation.DataHandler;
+import javax.xml.xpath.XPathExpressionException;
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.rmi.RemoteException;
+import java.util.Map;
+
+/**
+ * This test case is written to verify the fix for https://wso2.org/jira/browse/DS-1053
+ */
+public class DS1186JsonRenderTestCase extends DSSIntegrationTest {
+    private static final Log log = LogFactory.getLog(DS1186JsonRenderTestCase.class);
+
+    private final String serviceName = "JsonRenderService";
+    private String serviceEndPoint;
+    Map<String, String> headers;
+
+    @BeforeClass(alwaysRun = true)
+    public void serviceDeployment() throws Exception {
+        super.init();
+        addResource();
+        deployService(serviceName,
+                new DataHandler(new URL("file:///" + getResourceLocation() + File.separator + "samples" + File.separator + "dbs" + File.separator + "rdbms"
+                        + File.separator + "JsonRenderService.dbs")));
+        serviceEndPoint = getServiceUrlHttps(serviceName) + "/";
+
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void destroy() throws Exception {
+        deleteService(serviceName);
+        deleteResource();
+        cleanup();
+    }
+
+    @Test(groups = {"wso2.dss"}, description = "Check whether the JSON render service works when there is '&'", alwaysRun = true)
+    public void jsonRenderWithSecurity() throws Exception {
+        HttpResponse response = this.getHttpResponse(serviceEndPoint + "status", "application/json");
+        String receivedResult=response.getData();
+        String expectedResult = "{\"Entries\":{\"Entry\":[{\"status\":\"1 & 2\"}]}}";
+        Assert.assertNotNull(receivedResult, "Response is null");
+        Assert.assertTrue(expectedResult.equals(receivedResult.toString()), "Expected result not found");
+
+    }
+
+    /**
+     * This method will "Accept" header Types "application/json", etc..
+     * @param endpoint service endpoint
+     * @param contentType header type
+     * @return HttpResponse
+     * @throws Exception
+     */
+    private HttpResponse getHttpResponse(String endpoint, String contentType) throws Exception {
+
+        if (endpoint.startsWith("https://")) {
+            String urlStr = endpoint;
+            URL url = new URL(urlStr);
+            HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+            conn.setRequestMethod("GET");
+            conn.setDoOutput(true);
+            conn.setRequestProperty("Accept", contentType);
+            conn.setRequestProperty("charset", "UTF-8");
+
+            String encode = (new String((new Base64()).encode((userInfo.getUserName() + ":" + userInfo.getPassword())
+                        .getBytes()))).replaceAll("\n", "");
+                conn.setRequestProperty("Authorization", "Basic " + encode);
+
+            conn.setReadTimeout(10000);
+            conn.connect();
+            // Get the response
+            StringBuilder sb = new StringBuilder();
+            BufferedReader rd = null;
+            try {
+                rd = new BufferedReader(new InputStreamReader(conn.getInputStream()));
+                String line;
+                while ((line = rd.readLine()) != null) {
+                    sb.append(line);
+                }
+            } catch (FileNotFoundException ignored) {
+            } finally {
+                if (rd != null) {
+                    rd.close();
+                }
+            }
+            return new HttpResponse(sb.toString(), conn.getResponseCode());
+        }
+        return null;
+    }
+
+    private void addResource()
+            throws RemoteException, MalformedURLException, ResourceAdminServiceExceptionException,
+            XPathExpressionException {
+        ResourceAdminServiceClient resourceAdmin = new ResourceAdminServiceClient(dssContext.getContextUrls().getBackEndUrl()
+                , sessionCookie);
+        deleteResource();
+        resourceAdmin.addResource("/_system/config/automation/resources/policies/SecPolicy-withRoles.xml",
+                "text/comma-separated-values", "",
+                new DataHandler(new URL("file:///" + getResourceLocation()
+                        + File.separator + "resources" + File.separator
+                        + "SecPolicy-withRoles.xml")));
+    }
+
+
+    private void deleteResource()
+            throws RemoteException, MalformedURLException, ResourceAdminServiceExceptionException,
+            XPathExpressionException {
+        ResourceAdminServiceClient resourceAdmin = new ResourceAdminServiceClient(dssContext.getContextUrls().getBackEndUrl()
+                , sessionCookie);
+        resourceAdmin.deleteResource("/_system/config/automation/resources/policies/");
+    }
+
+
+
+
+}

--- a/modules/integration/tests-integration/tests/src/test/resources/artifacts/DSS/resources/SecPolicy-withRoles.xml
+++ b/modules/integration/tests-integration/tests/src/test/resources/artifacts/DSS/resources/SecPolicy-withRoles.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?><wsp:Policy xmlns:wsp="http://schemas.xmlsoap.org/ws/2004/09/policy" xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd" wsu:Id="UTOverTransport">
+	<wsp:ExactlyOne>
+		<wsp:All>
+			<sp:TransportBinding xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+				<wsp:Policy>
+					<sp:TransportToken>
+						<wsp:Policy>
+							<sp:HttpsToken RequireClientCertificate="false"/>
+						</wsp:Policy>
+					</sp:TransportToken>
+					<sp:AlgorithmSuite>
+						<wsp:Policy>
+							<sp:Basic256/>
+						</wsp:Policy>
+					</sp:AlgorithmSuite>
+					<sp:Layout>
+						<wsp:Policy>
+							<sp:Lax/>
+						</wsp:Policy>
+					</sp:Layout>
+					<sp:IncludeTimestamp/>
+				</wsp:Policy>
+			</sp:TransportBinding>
+			<sp:SignedSupportingTokens xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+				<wsp:Policy>
+					<sp:UsernameToken sp:IncludeToken="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy/IncludeToken/AlwaysToRecipient"/>
+				</wsp:Policy>
+			</sp:SignedSupportingTokens>
+		</wsp:All>
+	</wsp:ExactlyOne>
+	<rampart:RampartConfig xmlns:rampart="http://ws.apache.org/rampart/policy">
+		<rampart:encryptionUser>useReqSigCert</rampart:encryptionUser>
+		<rampart:timestampPrecisionInMilliseconds>true</rampart:timestampPrecisionInMilliseconds>
+		<rampart:timestampTTL>300</rampart:timestampTTL>
+		<rampart:timestampMaxSkew>300</rampart:timestampMaxSkew>
+		<rampart:timestampStrict>false</rampart:timestampStrict>
+		<rampart:tokenStoreClass>org.wso2.carbon.security.util.SecurityTokenStore</rampart:tokenStoreClass>
+		<rampart:nonceLifeTime>300</rampart:nonceLifeTime>
+	</rampart:RampartConfig>
+	<sec:CarbonSecConfig xmlns:sec="http://www.wso2.org/products/carbon/security">
+		<sec:Authorization>
+			<sec:property name="org.wso2.carbon.security.allowedroles">admin</sec:property>
+		</sec:Authorization>
+	</sec:CarbonSecConfig>
+</wsp:Policy>

--- a/modules/integration/tests-integration/tests/src/test/resources/artifacts/DSS/samples/dbs/rdbms/JsonRenderService.dbs
+++ b/modules/integration/tests-integration/tests/src/test/resources/artifacts/DSS/samples/dbs/rdbms/JsonRenderService.dbs
@@ -1,0 +1,14 @@
+<data disableStreaming="true" name="JsonRenderService" transports="http https">
+   <config id="h2ds">
+	  <property name="carbon_datasource_name">WSO2_CARBON_DB</property>
+   </config>
+   <query id="status" useConfig="h2ds">
+	  <sql>select '1 &amp; 2' as status</sql>
+	  <result outputType="json">{"Entries": {"Entry": [{"status": "$status"}]}}</result>
+   </query>
+   <resource method="GET" path="/status">
+	  <call-query href="status"/>
+   </resource>
+   <policy key="conf:/automation/resources/policies/SecPolicy-withRoles.xml"/>
+   <enableSec/>
+</data>

--- a/modules/integration/tests-integration/tests/src/test/resources/testng.xml
+++ b/modules/integration/tests-integration/tests/src/test/resources/testng.xml
@@ -178,6 +178,12 @@
         </classes>
     </test>
 
+    <test name="DSS-jira-issues-json-render" parallel="false" verbose="2">
+        <classes>
+            <class name="org.wso2.dss.integration.test.jira.issues.DS1186JsonRenderTestCase"/>
+        </classes>
+    </test>
+
 <!--    <test name = "DSS-gson-tests">
         <classes>
             <class name="org.wso2.dss.integration.test.jira.issues.CARBON15263JsonGsonFormatterSuperTenantModeTest"/>


### PR DESCRIPTION
Added test cases for DS-1186-JSON message rendering fails in DSS 3.2.2 with &. Test cases are added for 3.5.0 version.