### PR TITLE
Disable RequestJson Test case

### DIFF
--- a/modules/integration/tests-integration/tests/src/test/resources/testng.xml
+++ b/modules/integration/tests-integration/tests/src/test/resources/testng.xml
@@ -180,9 +180,10 @@
     </test>
 
     <test name="DSS-requestBox-tests" parallel="false" verbose="2">
-        <packages>
-            <package name="org.wso2.dss.integration.test.requestBox"/>
-        </packages>
+        <classes>
+            <class name="org.wso2.dss.integration.test.requestBox.RequestBoxTenantUserTestCase"/>
+            <class name="org.wso2.dss.integration.test.requestBox.RequestBoxTestCase"/>
+        </classes>
     </test>
 <!--TODO: Check what caused the test failure. Could be due to a change in Google side --> 
     <!--test name="DSS-gspread-tests" parallel="false" verbose="2">


### PR DESCRIPTION
Mistakenly I have enabled this test case. This test should be passed with a kernel upgrade. Fix has been committed to the axis2 repo.